### PR TITLE
feature/multitenant-with-basic-auth-headers

### DIFF
--- a/src/servicenow_mcp/server_sse.py
+++ b/src/servicenow_mcp/server_sse.py
@@ -15,17 +15,66 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.sse import SseServerTransport
 from starlette.applications import Starlette
 from starlette.requests import Request
+from starlette.responses import JSONResponse
 from starlette.routing import Mount, Route
 
 from servicenow_mcp.server import ServiceNowMCP
 from servicenow_mcp.utils.config import AuthConfig, AuthType, BasicAuthConfig, ServerConfig
 
 
-def create_starlette_app(mcp_server: Server, *, debug: bool = False) -> Starlette:
-    """Create a Starlette application that can serve the provided mcp server with SSE."""
+class MCPFactory:
+    """Factory class to create ServiceNowMCP instances on demand."""
+
+    @staticmethod
+    def create_mcp_instance(instance_url: str, username: str, password: str) -> ServiceNowMCP:
+        """
+        Create a new ServiceNowMCP instance with the provided credentials.
+
+        Args:
+            instance_url: ServiceNow instance URL
+            username: ServiceNow username
+            password: ServiceNow password
+
+        Returns:
+            A configured ServiceNowMCP instance
+        """
+        # Create basic auth config
+        auth_config = AuthConfig(
+            type=AuthType.BASIC, basic=BasicAuthConfig(username=username, password=password)
+        )
+
+        # Create server config
+        config = ServerConfig(instance_url=instance_url, auth=auth_config)
+
+        # Create and return MCP instance
+        return ServiceNowMCP(config)
+
+
+def create_starlette_app(debug: bool = False) -> Starlette:
+    """Create a Starlette application that creates MCP instances per request."""
     sse = SseServerTransport("/messages/")
 
-    async def handle_sse(request: Request) -> None:
+    async def handle_sse(request: Request) -> Union[None, JSONResponse]:
+        # Extract auth and instance URL from headers
+        instance_url = request.headers.get("X-ServiceNow-Instance-URL")
+        username = request.headers.get("X-ServiceNow-Username")
+        password = request.headers.get("X-ServiceNow-Password")
+
+        # Validate required headers
+        if not all([instance_url, username, password]):
+            return JSONResponse(
+                {"error": "Missing required headers for ServiceNow connection"}, status_code=400
+            )
+
+        # Create a new MCP instance for this specific request
+        mcp_instance = MCPFactory.create_mcp_instance(
+            instance_url=instance_url, username=username, password=password
+        )
+
+        # Get the underlying MCP server
+        mcp_server = mcp_instance.mcp_server._mcp_server
+
+        # Handle the connection
         async with sse.connect_sse(
             request.scope,
             request.receive,
@@ -65,62 +114,23 @@ class ServiceNowMCP(ServiceNowMCP):
         self.mcp_server = FastMCP("ServiceNow", port=8080, host="localhost")
         self._register_tools()
 
-    def start(self, host: str = "0.0.0.0", port: int = 8080):
-        """
-        Start the MCP server with SSE transport using Starlette and Uvicorn.
 
-        Args:
-            host: Host address to bind to
-            port: Port to listen on
-        """
-        # Create Starlette app with SSE transport
-        starlette_app = create_starlette_app(self.mcp_server._mcp_server, debug=True)
-
-        # Run using uvicorn
-        uvicorn.run(starlette_app, host=host, port=port)
-
-
-def create_servicenow_mcp(instance_url: str, username: str, password: str):
+def start_server(host: str = "0.0.0.0", port: int = 8080, debug: bool = False):
     """
-    Create a ServiceNow MCP server with minimal configuration.
+    Start the MCP server with SSE transport using Starlette and Uvicorn.
 
-    This is a simplified factory function that creates a pre-configured
-    ServiceNow MCP server with basic authentication.
+    This server creates new MCP instances per request based on headers.
 
     Args:
-        instance_url: ServiceNow instance URL
-        username: ServiceNow username
-        password: ServiceNow password
-
-    Returns:
-        A configured ServiceNowMCP instance ready to use
-
-    Example:
-        ```python
-        from servicenow_mcp.server import create_servicenow_mcp
-
-        # Create an MCP server for ServiceNow
-        mcp = create_servicenow_mcp(
-            instance_url="https://instance.service-now.com",
-            username="admin",
-            password="password"
-        )
-
-        # Start the server
-        mcp.start()
-        ```
+        host: Host address to bind to
+        port: Port to listen on
+        debug: Enable debug mode
     """
+    # Create Starlette app with SSE transport
+    starlette_app = create_starlette_app(debug=debug)
 
-    # Create basic auth config
-    auth_config = AuthConfig(
-        type=AuthType.BASIC, basic=BasicAuthConfig(username=username, password=password)
-    )
-
-    # Create server config
-    config = ServerConfig(instance_url=instance_url, auth=auth_config)
-
-    # Create and return server
-    return ServiceNowMCP(config)
+    # Run using uvicorn
+    uvicorn.run(starlette_app, host=host, port=port)
 
 
 def main():
@@ -130,14 +140,11 @@ def main():
     parser = argparse.ArgumentParser(description="Run ServiceNow MCP SSE-based server")
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
     parser.add_argument("--port", type=int, default=8080, help="Port to listen on")
+    parser.add_argument("--debug", action="store_true", help="Enable debug mode")
     args = parser.parse_args()
 
-    server = create_servicenow_mcp(
-        instance_url=os.getenv("SERVICENOW_INSTANCE_URL"),
-        username=os.getenv("SERVICENOW_USERNAME"),
-        password=os.getenv("SERVICENOW_PASSWORD"),
-    )
-    server.start(host=args.host, port=args.port)
+    # Start the server
+    start_server(host=args.host, port=args.port, debug=args.debug)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds basic multi-tenant mcp server support with server instances created per request
Adds basic auth headers, expected in the request to authenticate use of the snow mcp server and tools.